### PR TITLE
docs: Remove archived, unmaintained alternate repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,3 @@ to ensure that bitcoind continues to run.
 
 - [docker-bitcoind](https://github.com/kylemanna/docker-bitcoind): sort of the
   basis for this repo, but configuration is a bit more confusing.
-- [docker-bitcoin](https://github.com/amacneil/docker-bitcoin): more complex, but
-  more granular versioning. Includes XT & classic.


### PR DESCRIPTION
amacneil/docker-bitcoin has been archived, and marked as no longer maintained, https://github.com/amacneil/docker-bitcoin/commit/c6e9810df176e0e8b4232a0a310adec933d095c0.