### PR TITLE
add support for `host.docker.internal`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN apk update \
   && rm -rf /bitcoin-${VERSION}-x86_64-linux-gnu.tar.gz \
   && apk del tar wget ca-certificates
 
+RUN ip -4 route list match 0/0 | awk '{print $3 "host.docker.internal"}' >> /etc/hosts
+
 EXPOSE 8332 8333 18332 18333 28332 28333
 
 ADD VERSION .

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ RUN apk update \
   && rm -rf /bitcoin-${VERSION}-x86_64-linux-gnu.tar.gz \
   && apk del tar wget ca-certificates
 
-RUN ip -4 route list match 0/0 | awk '{print $3 "host.docker.internal"}' >> /etc/hosts
-
 EXPOSE 8332 8333 18332 18333 28332 28333
 
 ADD VERSION .

--- a/bin/docker_entrypoint.sh
+++ b/bin/docker_entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+ip -4 route list match 0/0 | awk '{print $3 "\thost.docker.internal"}' >> /etc/hosts
+
 BITCOIN_DIR=/root/.bitcoin
 BITCOIN_CONF=${BITCOIN_DIR}/bitcoin.conf
 


### PR DESCRIPTION
useful for configuring a tor proxy
refer to https://github.com/docker/for-linux/issues/264