### PR TITLE
Add support for rpcbind

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ be captured in your shell history. Use an envfile if you are going to use
 `BTC_RPCPASSWORD`.
 
 If you want the RPC port to be accessible to remote hosts, remove the `127.0.0.1` from
-the `-p ...8332` line.
+the `-p ...8332` line and set `BTC_RPCBIND=0.0.0.0`.
 
 ### Using your own config/datadir
 
@@ -120,6 +120,7 @@ on environment variables passed to the container:
 | BTC_RPCUSER | btc |
 | BTC_RPCPASSWORD | <randomly generated> |
 | BTC_RPCPORT | 8332 |
+| BTC_RPCBIND | 127.0.0.1 |
 | BTC_RPCALLOWIP | ::/0 |
 | BTC_RPCCLIENTTIMEOUT | 30 |
 | BTC_DISABLEWALLET | 1 |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,10 @@ rpcallowip=${BTC_RPCALLOWIP:-::/0}
 # Listen for RPC connections on this TCP port:
 rpcport=${BTC_RPCPORT:-8332}
 
+# Bind to given address to listen for JSON-RPC connections.
+# Refer to the manpage or bitcoind -help for further details.
+rpcbind=${BTC_RPCBIND:-127.0.0.1}
+
 # Print to console (stdout) so that "docker logs bitcoind" prints useful
 # information.
 printtoconsole=${BTC_PRINTTOCONSOLE:-1}


### PR DESCRIPTION
Since version 0.18.0 you must specify `rpcbind` in order for bitcoind to listen on the RPC port.  If you don't specify `rpcbind` you may get an error similar to the one below.

```
WARNING: option -rpcallowip was specified without -rpcbind; this doesn't usually make sense
libevent: getaddrinfo: address family for nodename not supported
Binding RPC on address ::1 port 8332 failed.
```
