### PR TITLE
Support building from git, add image labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A Docker configuration with sane defaults for running a fully-validating
 Bitcoin node. Binaries are retrieved from bitcoincore.org and verified for integrity
 based on [the process described here](https://bitcoincore.org/en/download/).
 
+Optional building from arbitrary git objects is possible (and pretty convenient).
+
 ## **Warning**: don't trust the Docker registry
 
 References on the Docker registry (https://hub.docker.com) are mutable. A malicious
@@ -19,6 +21,25 @@ Or just build these images yourself.
 
 With most software this doesn't matter too much, but running an authentic copy of
 Bitcoin Core is really important!
+
+## **Warning**: don't trust Docker
+
+Consider whether your use of Bitcoin requires Docker. When you use a container runtime,
+you are using a lot of additional code written by other people, e.g. `runc`, `docker`,
+potentially `docker-compose`, potentially `podman`.
+
+Is it necessary to rely on these dependencies? More code running underneath bitcoind
+is more chance for someone to meddle with the operation of your node.
+
+## **Warning**: don't rely on Dockerfile particulars
+
+This repo may change Dockerfile implementation. Although the container interface itself
+(i.e. volume mounts, operational behavior) will remain stable, the implementation 
+of how that happens is subject to change.
+
+If your use relies on the particulars of, for example, the retrieval script
+(`get-bitcoin.sh`), please pin your usage of this repo to a particular git hash.
+
 
 ## Tags available
 
@@ -37,7 +58,31 @@ Bitcoin Core is really important!
 - 0.19.0
 - 0.19.1
 - 0.20.0
-- 0.20.1 (latest)
+- 0.20.1 
+- 0.21.0 
+- 0.21.1 
+- 0.21.2 
+- 22.0
+- 23.0
+
+As well as various git refs.
+
+
+## Labels available
+
+Each image is built with certain labels:
+
+- `bitcoin_source`: "release" or "git", depending on how the binaries were built
+- `bitcoin_version`: if source=release, the release version (e.g. `23.0`), if
+  source=git "git:<git ref>"
+- `git_ref`: if source=git, the tag or branch used to build the image
+- `git_sha`: if source=git, the specific git commit hash
+- `git_repo_url`: if source=git, the repo used to build
+
+Labels can be shown by running something like
+```sh
+% docker image inspect jamesob/bitcoind:22.0 | jq '.[0] .Config .Labels'
+```
 
 ## Quick start
 
@@ -97,7 +142,16 @@ $ docker build -t $YOUR_USER/bitcoind:$SOME_VERSION \
    --build-arg UID=$(id -u) \
    --build-arg GID=$(id -g) \
    --build-arg VERSION=$SOME_VERSION \
+   --build-arg SOURCE=release \
    .
+```
+
+To build an arbitrary git object:
+
+```
+$ ./bin/build-docker-bitcoin master
+$ ./bin/build-docker-bitcoin v24.0rc2
+$ ./bin/build-docker-bitcoin <some git object>
 ```
 
 ## Possible volume mounts

--- a/bin/build-docker-bitcoin
+++ b/bin/build-docker-bitcoin
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import fscm
+from fscm import run
+from clii import App
+
+cli = App()
+
+fscm.settings.run_safe = True
+
+DEFAULT_REPO_PATH = Path.home() / "src" / "bitcoin-reference"
+REPO_URL = "https://github.com/bitcoin/bitcoin"
+DOCKER_USERNAME = "jamesob"
+
+
+@cli.main
+def main(
+    git_ref: str,
+    docker_username: str = DOCKER_USERNAME,
+    repo_path: str = str(DEFAULT_REPO_PATH),  # type: ignore
+    push: bool = False,
+):
+    """
+    Args:
+        git_ref: the git ref to build, e.g. "master" or "jamesob/utxo-dumpload-compressed"
+
+    Kwargs:
+        docker_repo_name: the docker username to push the container into
+        repo_path: where the cached bitcoin repo will live
+    """
+    repo_path: Path = Path(repo_path)
+    if not repo_path.exists():
+        run(f"git clone {REPO_URL} {repo_path}")
+
+    remote = "origin"
+    if "/" in git_ref:
+        remote, git_ref = git_ref.split("/", 1)
+
+    remote_url = "https://github.com/bitcoin/bitcoin"
+    if remote != "origin":
+        remote_url = f"https://github.com/{remote}/bitcoin"
+
+    os.chdir(repo_path)
+
+    remotes = {l.split()[0] for l in run("git remote -v", q=True).stdout.splitlines()}
+
+    if remote not in remotes:
+        run(f"git remote add {remote} https://github.com/{remote}/bitcoin")
+        print(f"Added remote {remote}")
+
+    run("git fetch --all", q=True)
+
+    try:
+        sha = run(f"git rev-list -n 1 {remote}/{git_ref}", q=True).stdout.strip()
+    except fscm.CommandFailure:
+        # Try a tag
+        sha = run(f"git rev-list -n 1 {git_ref}", q=True).stdout.strip()
+
+    print(f"Resolved git ref {remote}/{git_ref} to {sha}")
+
+    os.chdir(str(fscm.this_dir_path().parent))
+
+    tags = [
+        f"{docker_username}/bitcoind:{git_ref}",
+        f"{docker_username}/bitcoind:{sha}",
+    ]
+    if git_ref == "master":
+        tags.append(f"{docker_username}/bitcoind:master-latest")
+
+    tag_str = " ".join(f"-t {tag}" for tag in tags)
+
+    run(
+        f"docker build {tag_str} "
+        '--build-arg "SOURCE=git" '
+        f'--build-arg "VERSION=git:{git_ref}" '
+        f'--build-arg "GIT_REF={git_ref}" '
+        f'--build-arg "GIT_SHA={sha}" '
+        f'--build-arg "GIT_REPO_URL={remote_url}" '
+        "."
+    )
+
+    print(f"Built container for {remote}/{git_ref} ({sha}) as {tags[0]}")
+
+    labels = json.loads(run(f"docker image inspect {tags[0]}", q=True).stdout)[0][
+        "Config"
+    ]["Labels"]
+
+    try:
+        # Sanity check the labels
+        assert labels['bitcoin-source'] == 'git'
+        assert labels['bitcoin-version'] == f'git:{git_ref}'
+        assert labels['git-sha'] == sha
+        assert labels['git-ref'] == git_ref
+        assert labels['git-repo-url'] == remote_url
+    except AssertionError:
+        print(f"Labels mismatch; expected {labels}")
+        sys.exit(1)
+
+    if push:
+        run("docker login docker.io")
+        for tag in tags:
+            run(f"docker push {tag}")
+
+
+if __name__ == "__main__":
+    cli.run()

--- a/bin/build_tag_push.sh
+++ b/bin/build_tag_push.sh
@@ -3,7 +3,7 @@
 set -eu
 
 VERSIONS_ABOVE=${VERSIONS_ABOVE:-0.0}
-VERSIONS=$(./bin/get-bitcoin.sh 2>&1 | grep '^  ' | tr -d '  ')
+VERSIONS=$(./bin/get-bitcoin --source release --version xx 2>&1 | grep '^  ' | tr -d '  ')
 
 docker login docker.io
 
@@ -17,7 +17,8 @@ for ver in $VERSIONS; do
   echo "--- building bitcoin $ver"
   echo
   echo
-  docker build -t "jamesob/bitcoind:${ver}" --build-arg "VERSION=${ver}" .
+  docker build -t "jamesob/bitcoind:${ver}" \
+    --build-arg "SOURCE=release" --build-arg "VERSION=${ver}" .
   read -p "Push? (y/N): " confirm && [[ $confirm == [yY] ]] && \
   docker push "jamesob/bitcoind:${ver}" "docker://docker.io/jamesob/bitcoind:${ver}"
 done

--- a/bin/get-bitcoin
+++ b/bin/get-bitcoin
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# vim: ft=python
+"""
+A script for obtaining Bitcoin Core binaries, either from a release or building
+from source.
+
+"""
+
+import argparse
+import sys
+import os
+import subprocess
+from pathlib import Path
+
+
+def sh(cmd, *args, **kwargs):
+    kwargs.setdefault("shell", True)
+    kwargs.setdefault("check", True)
+    kwargs.setdefault("text", True)
+    return subprocess.run(cmd, *args, **kwargs)
+
+
+def err(*args, **kwargs):
+    kwargs["file"] = sys.stderr
+    print(*args, **kwargs)
+
+
+RELEASE_VERSIONS = (
+    "0.13.0",
+    "0.13.1",
+    "0.13.2",
+    "0.14.3",
+    "0.15.2",
+    "0.16.3",
+    "0.17.0",
+    "0.17.0.1",
+    "0.17.1",
+    "0.17.2",
+    "0.18.0",
+    "0.18.1",
+    "0.19.0.1",
+    "0.19.1",
+    "0.20.0",
+    "0.20.1",
+    "0.20.2",
+    "0.21.0",
+    "0.21.1",
+    "0.21.2",
+    "22.0",
+    "23.0",
+)
+
+
+def prechecks():
+    if not (Path("/etc/debian_version").exists() or Path("/etc/lsb_release").exists()):
+        err("This script is intended for use on Debian-based systems.")
+        sys.exit(3)
+
+
+def from_release(version: str, install_prefix: str):
+    if version not in RELEASE_VERSIONS:
+        versions = "\n".join(f"  {v}" for v in RELEASE_VERSIONS)
+        err(f"Version {version} not available. Choose from:\n\n{versions}")
+        sys.exit(2)
+
+    URL_BASE = f"https://bitcoincore.org/bin/bitcoin-core-{version}"
+    FILENAME = f"bitcoin-{version}-x86_64-linux-gnu.tar.gz"
+
+    # Verify signing key fingerprints here:
+    #
+    #   https://github.com/bitcoin/bitcoin/tree/master/contrib/builder-keys
+
+    sh(f'curl -O "{URL_BASE}/SHA256SUMS.asc"')
+    sh(f'curl -O "{URL_BASE}/{FILENAME}"')
+
+    vertuple = tuple(int(i) for i in version.split("."))
+
+    if vertuple < (22, 0):
+        # In version 22.0, release signing changed from a single key signing in
+        # SHA256SUMS.asc to multiple keys signing SHA256SUMS.
+        #
+        # See here for more information: https://github.com/bitcoin/bitcoin/pull/23020
+
+        sh(
+            "gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "
+            "01EA5486DE18A882D4C2684590C8019E36C2E964"
+        )
+        sh(
+            "sha256sum --ignore-missing --check SHA256SUMS.asc "
+            f' | tee - | grep -o "{FILENAME}: OK"'
+        )
+        sh("gpg --verify SHA256SUMS.asc >gpg_verify_out 2>&1")
+        sh("grep '^gpg: Good signature from \"Wladimir J. van der Laan' gpg_verify_out")
+        sh(
+            "grep '^Primary key fingerprint: 01EA 5486 DE18 A882 D4C2  6845 90C8 019E 36C2 E964' "
+            "gpg_verify_out"
+        )
+    else:
+        # See bitcoin/contrib/builder-keys/keys.txt for current values.
+        #
+        # I've chosen a subset of builder keys here who are well-known and reliably
+        # sign for releases.
+
+        KEYS = (
+            # Wladimir
+            "71A3B16735405025D447E8F274810B012346C9A6",
+            # Hebasto
+            "D1DBF2C4B96F2DEBF4C16654410108112E7EA81F",
+            # Fanquake
+            "E777299FC265DD04793070EB944D35F9AC3DB76A",
+        )
+
+        for key in KEYS:
+            sh(f"gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys {key}")
+
+        VERIFY = {
+            "Wladimir J. van der Laan": "71A3 B167 3540 5025 D447  E8F2 7481 0B01 2346 C9A6",
+            "Hennadii Stepanov": "D1DB F2C4 B96F 2DEB F4C1  6654 4101 0811 2E7E A81F",
+            "Michael Ford": "E777 299F C265 DD04 7930  70EB 944D 35F9 AC3D B76A",
+        }
+
+        sh(f'curl -O "{URL_BASE}/SHA256SUMS"')
+        sh("gpg --verify SHA256SUMS.asc SHA256SUMS >gpg_verify_out 2>&1 || true")
+        sh("cat gpg_verify_out")
+
+        for name, fp in VERIFY.items():
+            sh(f"grep '^gpg: Good signature from \"{name}' gpg_verify_out")
+            sh(f"grep '^Primary key fingerprint: {fp}' gpg_verify_out")
+
+        sh(
+            f'sha256sum --ignore-missing --check SHA256SUMS | tee - | grep -o "{FILENAME}: OK"'
+        )
+
+    sh(f"tar -xzvf {FILENAME}")
+    dir = sh("find . -name 'bitcoin-*' -type d | head -n 1", capture_output=True).stdout.strip()
+    sh(f"ls -lah {dir}")
+    sh(f"rm {dir}/bin/bitcoin-qt")
+    sh(f"cp -r {dir}/* {install_prefix}")
+
+    print("\nBitcoin installed:\n")
+    sh(f"{install_prefix}/bin/bitcoind --version")
+
+
+def from_git(
+    gitref: str, gitsha: str, repo_url: str, configure_args: str, install_prefix: str
+):
+    sh(f"git clone {repo_url} /bitcoin")
+    os.chdir("/bitcoin")
+    sh(f"git checkout {gitref}")
+
+    gotsha = sh("git rev-list -n 1 HEAD", capture_output=True).stdout.strip()
+    if gotsha != gitsha:
+        err(f"Git SHA doesn't match: got '{gotsha}', expected '{gitsha}'")
+        sys.exit(2)
+
+    sh("./contrib/install_db4.sh .")
+    sh("./autogen.sh")
+    sh(
+        './configure BDB_LIBS="-L/bitcoin/db4/lib -ldb_cxx-4.8" '
+        f'BDB_CFLAGS="-I/bitcoin/db4/include" {configure_args}'
+    )
+    sh("make -j $(nproc --ignore 1)")
+    sh(f"mkdir -p {install_prefix}/bin")
+    sh(
+        "cp src/bitcoind src/bitcoin-cli src/bitcoin-tx src/bitcoin-util "
+        f"src/bitcoin-wallet src/test/test_bitcoin {install_prefix}/bin"
+    )
+
+
+def getparser():
+    ap = argparse.ArgumentParser()
+    ao = ap.add_argument
+
+    ao("source", help='either "release" or "git"')
+    ao("--install-prefix", help="where to move the binaries", default=".")
+
+    ao(
+        "--version",
+        help="if obtaining from release, which version to obtain",
+        default="",
+    )
+
+    ao("--git-ref", help="if obtaining from git, which tag/branch to build", default="")
+    ao("--git-sha", help="if obtaining from git, which commit to build", default="")
+    ao("--git-repo-url", default="https://github.com/bitcoin/bitcoin")
+    ao("--configure-args", help="pass additiona ./configure args", default="")
+
+    return ap
+
+
+if __name__ == "__main__":
+    parser = getparser()
+    args = parser.parse_args()
+    prechecks()
+
+    if args.source == "release":
+        from_release(args.version, args.install_prefix)
+    elif args.source == "git":
+        from_git(
+            args.git_ref,
+            args.git_sha,
+            args.git_repo_url,
+            args.configure_args,
+            args.install_prefix,
+        )
+    else:
+        err(f"source '{args.source}' unrecognized. choices: release, git")
+        sys.exit(1)

--- a/bin/get-bitcoin.sh
+++ b/bin/get-bitcoin.sh
@@ -39,6 +39,13 @@ err() {
   >&2 echo "$@"
 }
 
+err "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+err ""
+err "THIS SCRIPT IS DEPRECATED AND UNMAINTAINED. See ./bin/get-bitcoin."
+err ""
+err "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+
+
 if [ ! -f /etc/debian_version ] && [ ! -f /etc/lsb_release ]; then
   err "This script is intended for use on Debian-based systems."
   exit 1


### PR DESCRIPTION
Add a means of easily building from git objects (`./bin/build-docker-bitcoin`) as well as some default image labels.